### PR TITLE
Changed localhost to 127.0.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     <script>
       window.$ = window.jQuery = require("./node_modules/jquery/dist/jquery.min.js");
 
-      const expressAppUrl = "http://localhost:3000",
+      const expressAppUrl = "http://127.0.0.1:3000",
             spawn = require("child_process").spawn,
             node = spawn(".\\node.exe", ["./express-app/bin/www"], { cwd: process.cwd() }),
             request = require("request"),


### PR DESCRIPTION
A really small change to let users connect the electron app with the express instance without internet connection, it hangs while testing in windows with a connection error because cant resolve the 'localhost' name, however, there could be a better solution