### PR TITLE
set enable remote module on create Window

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,8 @@ function createWindow() {
     width: 640,
     height: 480,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
   mainWindow.loadURL(`file://${__dirname}/index.html`);


### PR DESCRIPTION
The solution to the issue #29 
In the current version of electron the remote module is being disabled by default which is why starting the express server didn't work after upgrading it.
Adding the enableRemoteModule flag when creating the window reenables it and allows the express server to start again in a build.