### PR TITLE
Added a simple guard that prevents an exception being thrown on application exit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,8 @@ function stripAnsiColors(text: string): string {
 }
 
 function redirectOutput(stream: Readable) {
-  stream.on("data", (data) => {
+  stream.on("data", (data: any) => {
+    if (!mainWindow) return;
     data.toString().split("\n").forEach((line: string) => {
       if (line !== "") {
         mainWindow!.webContents.send("server-log-entry", stripAnsiColors(line));


### PR DESCRIPTION
Locally I kept getting the same exception over and over when closing the program. 

It turns out that the server log entry was still firing slightly after the app had quit, leaving webContents undefined. 

Just needed a simple guard  return out once the app has been exited. 