### PR TITLE
Updated a few things I ran into with deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "electron-with-express",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "electron-with-express",
-            "version": "1.0.13",
+            "version": "1.0.14",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.2",
@@ -16,18 +16,19 @@
                 "express": "^4.18.2",
                 "http-errors": "^2.0.0",
                 "morgan": "^1.10.0",
-                "node-fetch": "^2.6.12",
+                "node-fetch": "^2.7.0",
                 "serve-favicon": "^2.5.0"
             },
             "devDependencies": {
+                "@types/body-parser": "^1.19.3",
                 "@types/cookie-parser": "^1.4.3",
                 "@types/express": "^4.17.17",
                 "@types/http-errors": "^2.0.1",
-                "@types/morgan": "^1.9.4",
+                "@types/morgan": "^1.9.5",
                 "@types/node": "^20.5.0",
-                "@types/node-fetch": "^2.6.4",
-                "electron": "^26.0.0",
-                "typescript": "^5.1.6"
+                "@types/node-fetch": "^2.6.0",
+                "electron": "^26.1.0",
+                "typescript": "^5.2.2"
             }
         },
         "node_modules/@electron/get": {
@@ -76,9 +77,9 @@
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+            "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -166,9 +167,9 @@
             "dev": true
         },
         "node_modules/@types/morgan": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
-            "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
+            "version": "1.9.6",
+            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.6.tgz",
+            "integrity": "sha512-xfKogz5WcKww2DAiVT9zxMgrqQt+Shq8tDVeLT+otoj6dJnkRkyJxMF51mHtUc3JCPKGk5x1EBU0buuGpfftlQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -628,9 +629,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-26.0.0.tgz",
-            "integrity": "sha512-x57bdCaDvgnlc41VOm/UWihJCCiI3OxJKiBgB/e5F7Zd6avo+61mO6IzQS7Bu/k/a1KPjou25EUORR6UPKznBQ==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-26.4.0.tgz",
+            "integrity": "sha512-FUEFwmIlflLxImRtTmDp8CWpH4KqlyAwga6vauaz6+882SmyC3bJRhgqOIT5s6rMbW25WezNiaqfKqHDJjz3pw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -1384,9 +1385,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.12",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -1834,9 +1835,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "electron-with-express",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "electron-with-express",
-            "version": "1.0.13",
+            "version": "1.0.14",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.2",
@@ -16,18 +16,19 @@
                 "express": "^4.18.2",
                 "http-errors": "^2.0.0",
                 "morgan": "^1.10.0",
-                "node-fetch": "^2.6.12",
+                "node-fetch": "^2.7.0",
                 "serve-favicon": "^2.5.0"
             },
             "devDependencies": {
+                "@types/body-parser": "^1.19.3",
                 "@types/cookie-parser": "^1.4.3",
                 "@types/express": "^4.17.17",
                 "@types/http-errors": "^2.0.1",
-                "@types/morgan": "^1.9.4",
+                "@types/morgan": "^1.9.5",
                 "@types/node": "^20.5.0",
-                "@types/node-fetch": "^2.6.4",
-                "electron": "^26.0.0",
-                "typescript": "^5.1.6"
+                "@types/node-fetch": "^2.6.6",
+                "electron": "^26.1.0",
+                "typescript": "^5.2.2"
             }
         },
         "node_modules/@electron/get": {
@@ -76,9 +77,9 @@
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+            "version": "1.19.3",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+            "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -166,9 +167,9 @@
             "dev": true
         },
         "node_modules/@types/morgan": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
-            "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
+            "version": "1.9.6",
+            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.6.tgz",
+            "integrity": "sha512-xfKogz5WcKww2DAiVT9zxMgrqQt+Shq8tDVeLT+otoj6dJnkRkyJxMF51mHtUc3JCPKGk5x1EBU0buuGpfftlQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -181,13 +182,13 @@
             "dev": true
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-            "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "form-data": "^3.0.0"
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/@types/qs": {
@@ -628,9 +629,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-26.0.0.tgz",
-            "integrity": "sha512-x57bdCaDvgnlc41VOm/UWihJCCiI3OxJKiBgB/e5F7Zd6avo+61mO6IzQS7Bu/k/a1KPjou25EUORR6UPKznBQ==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-26.4.0.tgz",
+            "integrity": "sha512-FUEFwmIlflLxImRtTmDp8CWpH4KqlyAwga6vauaz6+882SmyC3bJRhgqOIT5s6rMbW25WezNiaqfKqHDJjz3pw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -919,9 +920,9 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
             "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -1384,9 +1385,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.12",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -1834,9 +1835,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "electron-with-express",
-    "version": "1.0.14",
+    "version": "1.0.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "electron-with-express",
-            "version": "1.0.14",
+            "version": "1.0.13",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.2",
@@ -16,19 +16,18 @@
                 "express": "^4.18.2",
                 "http-errors": "^2.0.0",
                 "morgan": "^1.10.0",
-                "node-fetch": "^2.7.0",
+                "node-fetch": "^2.6.12",
                 "serve-favicon": "^2.5.0"
             },
             "devDependencies": {
-                "@types/body-parser": "^1.19.3",
                 "@types/cookie-parser": "^1.4.3",
                 "@types/express": "^4.17.17",
                 "@types/http-errors": "^2.0.1",
-                "@types/morgan": "^1.9.5",
+                "@types/morgan": "^1.9.4",
                 "@types/node": "^20.5.0",
-                "@types/node-fetch": "^2.6.6",
-                "electron": "^26.1.0",
-                "typescript": "^5.2.2"
+                "@types/node-fetch": "^2.6.4",
+                "electron": "^26.0.0",
+                "typescript": "^5.1.6"
             }
         },
         "node_modules/@electron/get": {
@@ -77,9 +76,9 @@
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.3",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
-            "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -167,9 +166,9 @@
             "dev": true
         },
         "node_modules/@types/morgan": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.6.tgz",
-            "integrity": "sha512-xfKogz5WcKww2DAiVT9zxMgrqQt+Shq8tDVeLT+otoj6dJnkRkyJxMF51mHtUc3JCPKGk5x1EBU0buuGpfftlQ==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
+            "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -182,13 +181,13 @@
             "dev": true
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+            "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "form-data": "^4.0.0"
+                "form-data": "^3.0.0"
             }
         },
         "node_modules/@types/qs": {
@@ -629,9 +628,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "26.4.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-26.4.0.tgz",
-            "integrity": "sha512-FUEFwmIlflLxImRtTmDp8CWpH4KqlyAwga6vauaz6+882SmyC3bJRhgqOIT5s6rMbW25WezNiaqfKqHDJjz3pw==",
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-26.0.0.tgz",
+            "integrity": "sha512-x57bdCaDvgnlc41VOm/UWihJCCiI3OxJKiBgB/e5F7Zd6avo+61mO6IzQS7Bu/k/a1KPjou25EUORR6UPKznBQ==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -920,9 +919,9 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
             "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -1385,9 +1384,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -1835,9 +1834,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
         "serve-favicon": "^2.5.0"
     },
     "devDependencies": {
+        "@types/body-parser": "^1.19.3",
         "@types/cookie-parser": "^1.4.3",
         "@types/express": "^4.17.17",
         "@types/http-errors": "^2.0.1",
         "@types/morgan": "^1.9.5",
         "@types/node": "^20.5.0",
-        "@types/node-fetch": "^2.7.0",
+        "@types/node-fetch": "^2.6.0",
         "electron": "^26.1.0",
         "typescript": "^5.2.2"
     }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
         "serve-favicon": "^2.5.0"
     },
     "devDependencies": {
+        "@types/body-parser": "^1.19.3",
         "@types/cookie-parser": "^1.4.3",
         "@types/express": "^4.17.17",
         "@types/http-errors": "^2.0.1",
         "@types/morgan": "^1.9.5",
         "@types/node": "^20.5.0",
-        "@types/node-fetch": "^2.7.0",
+        "@types/node-fetch": "^2.6.6",
         "electron": "^26.1.0",
         "typescript": "^5.2.2"
     }

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
         "serve-favicon": "^2.5.0"
     },
     "devDependencies": {
-        "@types/body-parser": "^1.19.3",
         "@types/cookie-parser": "^1.4.3",
         "@types/express": "^4.17.17",
         "@types/http-errors": "^2.0.1",
         "@types/morgan": "^1.9.5",
         "@types/node": "^20.5.0",
-        "@types/node-fetch": "^2.6.6",
+        "@types/node-fetch": "^2.7.0",
         "electron": "^26.1.0",
         "typescript": "^5.2.2"
     }


### PR DESCRIPTION
On fresh install on my machine I ran into a few issues.

The types were missing for body-parser and I had a weird issue where the node fetch types were trying to pull the same version number as the node-fetch library, but it didn't exist.

2.6.6 is the latest and seems to work fine for me. Not sure what happened there, they may have changed their versioning scheme or something. 

This got me up and running again